### PR TITLE
Typo fix - GitHub link for airsonic-advanced

### DIFF
--- a/website/apps/stable/airsonic-advanced/index.md
+++ b/website/apps/stable/airsonic-advanced/index.md
@@ -7,7 +7,7 @@ TrueCharts are designed to be installed as TrueNAS SCALE app only. We can not gu
 
 ## Source Code
 
-* <https://github.com/airsonic/airsonic-advanced>
+* <https://github.com/airsonic-advanced/airsonic-advanced>
 * <https://hub.docker.com/r/airsonicadvanced/airsonic-advanced>
 
 ## Requirements


### PR DESCRIPTION
**Description**

⚒️ Fixes the link to airsonic-advanced/airsonic-advanced (existing link 404s as it points to airsonic/airsonic-advanced)

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [x] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
n/a

**📃 Notes:**
n/a

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
